### PR TITLE
chore: 補上 LICENSE 檔與 package.json 的 license 欄位

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Theodore Huang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "Chrome Side Panel for reliable multi-AI workflows across ChatGPT, Claude, Gemini, and Grok",
   "private": true,
+  "license": "MIT",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
Closes #6（第 1 點）

## Problem

`README.md` 兩處宣告 MIT（第 7 行的 badge 列與第 103 行的 License 段落），但 repo 根目錄沒有 `LICENSE` 檔，`package.json` 也沒有 `license` 欄位。

## Cause

授權宣告只寫在 README 散文中，沒有對應的授權全文與著作權聲明。

## Fix

- 新增 `LICENSE`：MIT 全文 + `Copyright (c) 2026 Theodore Huang`
- `package.json` 加上 `"license": "MIT"`

這樣可以解決兩個實際問題：

1. MIT 的核心義務是「保留著作權聲明與授權條款全文」。原本沒有 `Copyright (c) <年份> <姓名>` 這行，想遵守授權的人不知道要保留什麼
2. 缺 LICENSE 檔時 GitHub 側邊欄不顯示授權，多數工具與使用者會預設為「保留所有權利」，反而比你宣告的本意更嚴格

## 需要你確認

copyright 行的內容是我推測的，請在 review 直接指出要改成什麼：

- **姓名**：取自 GitHub 帳號 `teddashh` 的顯示名稱 `Theodore Huang`。commit 紀錄中另有 `Ted Theodore J Huang / FPCUSA Management Center`，若著作權應歸屬公司或想用其他寫法請告知
- **年份**：`2026`，取自 repo 首次提交年份

## Verification

- `node -e "require('./package.json')"` 可解析，`license` 欄位為 `MIT`
- 未更動 README（既有宣告與本 PR 一致，無需修改）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
