### PR TITLE
fix: report ready status the moment a SPA composer mounts

### DIFF
--- a/src/content/base.ts
+++ b/src/content/base.ts
@@ -62,6 +62,7 @@ export function createContentScript(config: ContentScriptConfig): void {
   let activeWorkflowId: string | undefined;
   let responseObserver: MutationObserver | undefined;
   let sawGenerationActivity = false;
+  let lastReportedLoggedIn: boolean | undefined;
   const sendTimeouts = new Set<number>();
 
   function isContextValid(): boolean {
@@ -97,7 +98,8 @@ export function createContentScript(config: ContentScriptConfig): void {
       cleanup();
       return;
     }
-    safeSendMessage({ action: 'STATUS_REPORT', provider, payload: { loggedIn: loginDetector() } });
+    lastReportedLoggedIn = loginDetector();
+    safeSendMessage({ action: 'STATUS_REPORT', provider, payload: { loggedIn: lastReportedLoggedIn } });
   }
 
   async function sendMessage(text: string, requestId?: string, workflowId?: string): Promise<void> {
@@ -242,6 +244,9 @@ export function createContentScript(config: ContentScriptConfig): void {
 
   function observeResponses(): void {
     responseObserver = new MutationObserver(() => {
+      // Claude/SPA composers mount several seconds after load; re-report the moment
+      // login state flips so the card reaches "ready" without waiting for the 10s poll.
+      if (lastReportedLoggedIn !== undefined && loginDetector() !== lastReportedLoggedIn) reportStatus();
       if (!waitingForResponse || isThinking()) return;
       updateResponse();
     });


### PR DESCRIPTION
## Problem
After opening a provider whose UI is a SPA (notably Claude), the connection card could stay "not ready" for up to ~10 seconds even though the tab was already logged in — so the user couldn't send yet.

## Cause
The card only turns ready when the content script reports `loggedIn: true`, which requires the composer (`.ProseMirror`) to exist **at report time**. Claude's composer mounts several seconds after page load, but status is only probed at tab `complete`, on card click, and via a 10s poll. A probe landing before the editor mounted reported `login-required`, leaving the card stuck until the next poll.

## Fix
Reuse the content script's existing `responseObserver` MutationObserver to re-report status the instant login state flips (i.e. when the editor appears), so the card reaches "ready" within milliseconds of the composer mounting instead of waiting for the 10s poll. A `lastReportedLoggedIn` guard avoids redundant reports.

Single-file, ~6 lines, no new dependencies. Applies to all providers; most impactful for Claude.

## Verification
- `npm run typecheck` passes.
- Verified in Chrome: opening Claude now flips the card to "ready" as soon as the ProseMirror editor mounts; all four provider cards reach ready.
- (No test suite exists in this repo; behaviour is DOM/MutationObserver timing, verified manually.)

Note: `dist/` is committed in this repo but I left the rebuilt artifact out to keep the diff reviewable — happy to add the rebuilt `dist/content/*.js` if you prefer the shipped bundle in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)