### PR TITLE
ci: add extension verification guardrails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:15"
+      timezone: America/New_York
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -39,7 +41,12 @@ jobs:
         run: npm run verify
 
       - name: Confirm committed build is current
-        run: git diff --exit-code -- dist
+        run: |
+          changes="$(git status --porcelain --untracked-files=all -- dist)"
+          if [ -n "$changes" ]; then
+            printf '%s\n' "$changes"
+            exit 1
+          fi
 
       - name: Upload unpacked extension
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.18.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
+      - name: Verify source and production build
+        run: npm run verify
+
+      - name: Confirm committed build is current
+        run: git diff --exit-code -- dist
+
+      - name: Upload unpacked extension
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: multi-ai-chat-${{ github.sha }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 14

--- a/README.de.md
+++ b/README.de.md
@@ -38,7 +38,7 @@ Steuere deine angemeldeten **ChatGPT-, Claude-, Gemini- und Grok-Tabs** als geme
 
 ## Aus dem Quellcode installieren
 
-Voraussetzungen: Chrome 114+, Node.js 20+ und npm.
+Voraussetzungen: Chrome 114+, Node.js 22.18+ und npm.
 
 ```sh
 git clone https://github.com/teddashh/multi-ai-chat.git

--- a/README.ja.md
+++ b/README.ja.md
@@ -38,7 +38,7 @@
 
 ## ソースからインストール
 
-Chrome 114+、Node.js 20+、npm が必要です。
+Chrome 114+、Node.js 22.18+、npm が必要です。
 
 ```sh
 git clone https://github.com/teddashh/multi-ai-chat.git

--- a/README.ko.md
+++ b/README.ko.md
@@ -38,7 +38,7 @@
 
 ## 소스에서 설치
 
-Chrome 114+, Node.js 20+, npm이 필요합니다.
+Chrome 114+, Node.js 22.18+, npm이 필요합니다.
 
 ```sh
 git clone https://github.com/teddashh/multi-ai-chat.git

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A lightweight Chrome extension that turns your existing **ChatGPT, Claude, Gemin
 
 ## Install from source
 
-Requirements: Chrome 114+, Node.js 20+, and npm.
+Requirements: Chrome 114+, Node.js 22.18+, and npm.
 
 ```sh
 git clone https://github.com/teddashh/multi-ai-chat.git

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -41,7 +41,7 @@
 
 ## 從原始碼安裝
 
-需要 Chrome 114+、Node.js 20+ 與 npm。
+需要 Chrome 114+、Node.js 22.18+ 與 npm。
 
 ```sh
 git clone https://github.com/teddashh/multi-ai-chat.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "webpack-cli": "^7.2.1"
       },
       "engines": {
-        "node": ">=22.6.0"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": ">=22.6.0"
+    "node": ">=22.18.0"
   },
   "scripts": {
     "dev": "webpack --watch --mode development",
     "build": "webpack --mode production",
+    "check:version": "node scripts/check-version.js",
     "typecheck": "tsc --noEmit",
     "test": "node --test \"test/*.test.mts\"",
-    "verify": "npm run typecheck && npm run test && npm run build",
+    "verify": "npm run typecheck && npm run test && npm run build && npm run check:version",
     "clean": "rimraf dist"
   },
   "devDependencies": {

--- a/scripts/check-version.js
+++ b/scripts/check-version.js
@@ -1,0 +1,31 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
+}
+
+const packageJson = readJson('package.json');
+const packageLock = readJson('package-lock.json');
+const sourceManifest = readJson('public/manifest.json');
+const builtManifest = readJson('dist/manifest.json');
+
+const versions = new Map([
+  ['package.json', packageJson.version],
+  ['package-lock.json', packageLock.version],
+  ['package-lock.json packages[""]', packageLock.packages?.['']?.version],
+  ['public/manifest.json', sourceManifest.version],
+  ['dist/manifest.json', builtManifest.version],
+]);
+
+const expected = packageJson.version;
+const mismatches = [...versions].filter(([, version]) => version !== expected);
+
+if (mismatches.length > 0) {
+  const details = mismatches.map(([file, version]) => `${file}: ${String(version)}`).join('\n');
+  throw new Error(`Extension versions must all match ${expected}:\n${details}`);
+}
+
+console.log(`Version ${expected} is consistent across package and manifest files.`);


### PR DESCRIPTION
## Summary

- add a least-privilege CI workflow with immutable action pins
- run install, full verification, high-severity audit, committed-build freshness, and artifact upload on every PR and master push
- add weekly npm and GitHub Actions Dependabot checks
- enforce package/lock/source-manifest/built-manifest version consistency
- correct all five READMEs and the package engine to Node.js 22.18+, the first Node 22 release where the repository's `.mts` tests run without an experimental flag

## Validation

- `npm ci`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm run verify` — typecheck, 11 tests, production build, version consistency
- exact-minimum smoke with Node.js 22.18.0 — passes
- Node.js 22.6.0 regression check — confirmed the previous minimum could not load the `.mts` tests
- `git diff --exit-code -- dist`