### PR TITLE
fix(site): polish localized responsive layout

### DIFF
--- a/site/assets/site.js
+++ b/site/assets/site.js
@@ -120,7 +120,7 @@
       navGitHub: "GitHub",
       languageLabel: "語言",
       eyebrow: "開放原始碼 · v0.2.1 · Chrome 114+",
-      heroTitle: "一個問題。\n四種觀點。\n更清楚的答案。",
+      heroTitle: "一個問題。\n四種觀點。\n答案更清楚。",
       heroLead: "在專注的 Side Panel 中協調 ChatGPT、Claude、Gemini、Grok。Multi-AI Chat 使用你已登入的分頁，不需要模型 API Key，也沒有額外的對話後端。",
       downloadButton: "下載 v0.2.1 ZIP",
       installButton: "安裝指南",

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -746,6 +746,10 @@ pre {
   gap: 2rem;
 }
 
+.source-build-body > * {
+  min-width: 0;
+}
+
 .source-build-body p {
   margin: 0;
 }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -746,10 +746,6 @@ pre {
   gap: 2rem;
 }
 
-.source-build-body > * {
-  min-width: 0;
-}
-
 .source-build-body p {
   margin: 0;
 }
@@ -948,6 +944,12 @@ pre {
   margin-top: 2rem;
 }
 
+@media (min-width: 50.0625rem) {
+  html[lang="zh-TW"] .hero h1 {
+    font-size: clamp(3rem, 5.7vw, 5.1rem);
+  }
+}
+
 @media (max-width: 68rem) {
   .header-links a:nth-child(-n + 3) {
     display: none;
@@ -969,6 +971,11 @@ pre {
   .product-shot {
     width: min(52rem, 100%);
     transform: none;
+  }
+
+  .product-shot::before,
+  .product-shot::after {
+    display: none;
   }
 
   .feature-grid {


### PR DESCRIPTION
## Summary
- tighten the Traditional Chinese hero line and cap its desktop display size so it stays on the intended three lines
- remove off-canvas screenshot decorations in the single-column layout so they cannot create page-level horizontal scrolling
- preserve horizontal scrolling inside long source and checksum command blocks

## Validation
- `npm run verify` (42 tests, typecheck, production build, version check)
- `node --check site/assets/site.js`
- `git diff --check`
- live/headless Chrome checks at 320, 375, 390, 800, 801, 820, 879, 880, 900, 1024, 1088, 1440, 1904, and 2560 px
- Traditional Chinese hero stays at three lines; page scrollX remains 0; source code block retains `overflow-x: auto`