### PR TITLE
fix(site): contain hero artwork at mid widths

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -950,6 +950,13 @@ pre {
   }
 }
 
+@media (max-width: 84rem) {
+  .product-shot::before,
+  .product-shot::after {
+    display: none;
+  }
+}
+
 @media (max-width: 68rem) {
   .header-links a:nth-child(-n + 3) {
     display: none;
@@ -971,11 +978,6 @@ pre {
   .product-shot {
     width: min(52rem, 100%);
     transform: none;
-  }
-
-  .product-shot::before,
-  .product-shot::after {
-    display: none;
   }
 
   .feature-grid {


### PR DESCRIPTION
## Summary
- extend the responsive boundary for off-canvas hero artwork from 68rem to 84rem
- remove the remaining 1089–1335px page-level horizontal overflow while keeping the decoration at widths where it fits

## Validation
- `git diff --check`
- Chrome CDP width sweep at 320, 375, 390, 1088, 1089, 1200, 1300, 1335, 1340, 1344, 1345, and 1440 px
- page scroll delta remains zero; mobile source code blocks retain their own `overflow-x: auto`